### PR TITLE
fix(ci): audit only production deps in publish workflows

### DIFF
--- a/.github/workflows/publish-protocol-core.yaml
+++ b/.github/workflows/publish-protocol-core.yaml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run security audit
-        run: pnpm audit --audit-level=high
+        run: pnpm audit --audit-level=high --prod
 
       - name: Run linter
         run: pnpm --filter @quickswap-defi/protocol-core lint

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run security audit
-        run: pnpm audit --audit-level=high
+        run: pnpm audit --audit-level=high --prod
 
       - name: Run linter
         run: pnpm --filter @quickswap-defi/sdk lint


### PR DESCRIPTION
## Summary

- Add `--prod` flag to `pnpm audit` in both publish workflows
- DevDependencies (vitest, tsup, jsdom) have known moderate/high vulnerabilities that don't ship to consumers
- Without `--prod`, the security audit blocks publishing due to devDep false positives

## Test plan

- [x] protocol-core has zero prod deps — audit passes trivially
- [x] SDK prod deps have no known high vulnerabilities