### PR TITLE
fix(ci): remove pnpm cache from version-bump job

### DIFF
--- a/.github/workflows/publish-protocol-core.yaml
+++ b/.github/workflows/publish-protocol-core.yaml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run security audit
-        run: pnpm audit --audit-level=high
+        run: pnpm audit --audit-level=high --prod
 
       - name: Run linter
         run: pnpm --filter @quickswap-defi/protocol-core lint

--- a/.github/workflows/publish-protocol-core.yaml
+++ b/.github/workflows/publish-protocol-core.yaml
@@ -159,7 +159,6 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '20'
-          cache: 'pnpm'
 
       - name: Configure Git
         run: |

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run security audit
-        run: pnpm audit --audit-level=high
+        run: pnpm audit --audit-level=high --prod
 
       - name: Run linter
         run: pnpm --filter @quickswap-defi/sdk lint

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -156,7 +156,6 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '20'
-          cache: 'pnpm'
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

- Remove `cache: 'pnpm'` from `setup-node` in the `version-bump` job
- The version-bump job only runs `pnpm version` — it never runs `pnpm install`, so there's no pnpm store to cache
- The `setup-node` post-cleanup step fails trying to save a non-existent cache path, marking the entire job as FAILED and skipping the publish step

## Root cause

`actions/setup-node` with `cache: 'pnpm'` tries to save the pnpm store on job cleanup. Since version-bump doesn't install dependencies, the store path doesn't exist → `Path Validation Error` → job marked failed → publish skipped.

## Test plan

- [x] Verified version-bump job doesn't use `pnpm install`
- [ ] Re-run publish workflow after merge