### PR TITLE
fix(protocol-core): add repository field for npm provenance

### DIFF
--- a/packages/protocol-core/package.json
+++ b/packages/protocol-core/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.0",
   "license": "MIT",
   "description": "Pure protocol knowledge for QuickSwap DEX — chains, stablecoins, fees, schema detection",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QuickSwap/QuickSwap-sdk",
+    "directory": "packages/protocol-core"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,11 @@
   "files": [
     "dist"
   ],
-  "repository": "https://github.com/QuickSwap/QuickSwap-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QuickSwap/QuickSwap-sdk",
+    "directory": "packages/sdk"
+  },
   "keywords": [
     "quickswap",
     "matic",


### PR DESCRIPTION
## Summary

Add `repository` field to protocol-core `package.json`. npm provenance with sigstore requires `repository.url` to match the GitHub repo — without it, `npm publish --provenance` fails with E422.

## Test plan

- [ ] Re-run Publish Protocol Core workflow after merge — should pass provenance verification