### PR TITLE
fix(ci): push tags explicitly for GitHub Release creation

### DIFF
--- a/.github/workflows/publish-protocol-core.yaml
+++ b/.github/workflows/publish-protocol-core.yaml
@@ -241,7 +241,8 @@ jobs:
           git add packages/protocol-core/package.json
           git commit -m "chore(release): protocol-core v${VERSION} [skip ci]"
           git tag "protocol-core/v${VERSION}"
-          git push origin HEAD --follow-tags
+          git push origin HEAD
+          git push origin "protocol-core/v${VERSION}"
 
       - name: Get published version
         id: version

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -238,7 +238,8 @@ jobs:
           git add packages/sdk/package.json
           git commit -m "chore(release): sdk v${VERSION} [skip ci]"
           git tag "sdk/v${VERSION}"
-          git push origin HEAD --follow-tags
+          git push origin HEAD
+          git push origin "sdk/v${VERSION}"
 
       - name: Get published version
         id: version


### PR DESCRIPTION
## Summary

Replace `git push --follow-tags` with explicit tag push. Tags with slashes (`protocol-core/v0.1.1`) are not pushed by `--follow-tags`, causing `gh release create` to fail with "tag exists locally but has not been pushed".

## Root cause

`git push --follow-tags` only pushes tags that are reachable from the pushed refs AND are annotated. Our tags are lightweight and contain `/`, which `--follow-tags` doesn't handle reliably.

## Test plan

- [ ] Re-run publish workflow — tag should be pushed and GitHub Release created